### PR TITLE
Remove obsolete version attribute from docker-compose.yml files

### DIFF
--- a/code/burpsuite/docker-compose.yml
+++ b/code/burpsuite/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   burpsuite:
     build:

--- a/code/composegen/composegen.py
+++ b/code/composegen/composegen.py
@@ -6,7 +6,7 @@ from typing import List
 
 
 def get_template(application_type, coverage_path) -> str:
-    return f"""version: "3.7"
+    return f"""
 services:
   composegen:
     build:

--- a/code/docker-compose.yml
+++ b/code/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   composegen:
     build:

--- a/code/wapiti/docker-compose.yml
+++ b/code/wapiti/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   wapiti:
     build:

--- a/code/wfuzz/docker-compose.yml
+++ b/code/wfuzz/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   wfuzz:
     build:

--- a/code/zap/docker-compose.yml
+++ b/code/zap/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   zap:
     build:


### PR DESCRIPTION
Remove the obsolete `version` attribute from multiple `docker-compose.yml` files to avoid potential confusion.

* **code/burpsuite/docker-compose.yml**
  - Remove the `version` attribute from the file.

* **code/composegen/composegen.py**
  - Remove the `version` attribute from the `get_template` function.

* **code/docker-compose.yml**
  - Remove the `version` attribute from the file.

* **code/wapiti/docker-compose.yml**
  - Remove the `version` attribute from the file.

* **code/wfuzz/docker-compose.yml**
  - Remove the `version` attribute from the file.

* **code/zap/docker-compose.yml**
  - Remove the `version` attribute from the file.

Ref: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete

