### PR TITLE
Add jpg and webp support to php-gd

### DIFF
--- a/code/web/Dockerfile
+++ b/code/web/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y iputils-ping dnsutils zip # For web too
 
 RUN docker-php-ext-configure bcmath
 RUN docker-php-ext-configure exif
-RUN docker-php-ext-configure gd
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp
 RUN docker-php-ext-configure intl
 RUN docker-php-ext-configure pdo_mysql 
 RUN docker-php-ext-configure mysqli


### PR DESCRIPTION
This adds support for jpg and webp to php-gd in the web container.

Without this, a few (somewhat) commonly used PHP functions will be absent so there may be show-stopping errors like:

> Call to undefined function imagecreatefromjpeg()